### PR TITLE
Add DebugRC endpoint for segmenting physics log

### DIFF
--- a/EverestInterop/DebugRcPage.cs
+++ b/EverestInterop/DebugRcPage.cs
@@ -1045,6 +1045,21 @@ namespace Celeste.Mod.ConsistencyTracker.EverestInterop
             }
         };
 
+        // +------------------------------------------+
+        // |            /cct/segmentRecording         |
+        // +------------------------------------------+
+        private static readonly RCEndPoint SegmentPhysicsLogEndpoint = new RCEndPoint() {
+            Path = "/cct/segmentRecording",
+            PathHelp = "/cct/segmentRecording",
+            Name = "Consistency Tracker Segment Physics Log [GET]",
+            InfoHTML = "Manually segment the physics recording",
+            Handle = c => {
+                bool requestedJson = CheckRequest(c);
+
+                Mod.PhysicsLog.SegmentLog(false);
+                WriteResponse(c, RCErrorCode.OK, requestedJson);
+            }
+        };
 
         #endregion
 
@@ -1365,6 +1380,7 @@ namespace Celeste.Mod.ConsistencyTracker.EverestInterop
             SaveRecordingEndpoint,
             RenameRecordingEndpoint,
             DeleteRecordingEndpoint,
+            SegmentPhysicsLogEndpoint,
 
             //Other
             SetRootFolderEndPoint,


### PR DESCRIPTION
The tool I'm building wants to run a TAS while physics recording is active, and then process that log into a nice image.

Problem is, some TASes don't end in a state where the recording is finished, so I have to manually tab into celeste and RTM or similar to force segmenting the log.

With this debugrc page I can do that automatically.

https://github.com/viddie/ConsistencyTrackerMod/assets/22177966/d418454f-49e1-4ace-ac3a-431c6a0eeb7a

