### PR TITLE
Fix the jump state bug

### DIFF
--- a/ConsistencyTracker.csproj
+++ b/ConsistencyTracker.csproj
@@ -16,7 +16,7 @@
     <CelesteIsCore Condition="Exists('$(CelestePrefix)\Celeste.dll')">true</CelesteIsCore>
     <CelestePrefix Condition="$(CelesteIsCore)">$(CelestePrefix)\legacyRef</CelestePrefix>
     
-    <CelesteType Condition="'$(CelesteType)' == '' And Exists('$(CelesteGamePath)\BuildIsXNA.txt')">XNA</CelesteType>
+    <CelesteType Condition="'$(CelesteType)' == '' And Exists('$(CelestePrefix)\BuildIsXNA.txt')">XNA</CelesteType>
     <CelesteType Condition="'$(CelesteType)' == ''">FNA</CelesteType>
     <XNAPath Condition="'$(XNAPath)' == ''">$(WINDIR)\Microsoft.NET\assembly\GAC_32\{0}\v4.0_4.0.0.0__842cf8be1de50553\{0}.dll</XNAPath>
   </PropertyGroup>

--- a/PhysicsLog/PhysicsLogger.cs
+++ b/PhysicsLog/PhysicsLogger.cs
@@ -703,20 +703,34 @@ namespace Celeste.Mod.ConsistencyTracker.PhysicsLog
             return flags;
         }
 
-
-        private bool PhysicsLogHeldJumpLastFrame;
+        private bool PhysicsLogHoldingJump;
         private bool PhysicsLogHoldingSecondJump;
+
         private void UpdateJumpState() {
-            //Log($"Pre frame: Jump.Check -> {Input.Jump.Check}, Jump.Pressed -> {Input.Jump.Pressed}, Held Jump Last Frame -> {PhysicsLogHeldJumpLastFrame}, Holding Second Jump -> {PhysicsLogHoldingSecondJump}");
-            if (Input.Jump.Check) {
-                if (PhysicsLogHeldJumpLastFrame && Input.Jump.Pressed) {
-                    PhysicsLogHoldingSecondJump = !PhysicsLogHoldingSecondJump;
+            VirtualButton jump = Input.Jump;
+            Binding binding = jump.Binding;
+            int jumpKeysHeld = 0;
+
+            for (int i = 0; i < binding.Keyboard.Count; i++) {
+                if (MInput.Keyboard.Check(binding.Keyboard[i])) {
+                    jumpKeysHeld++;
                 }
-                PhysicsLogHeldJumpLastFrame = true;
-            } else {
-                PhysicsLogHeldJumpLastFrame = false;
-                PhysicsLogHoldingSecondJump = false;
             }
+
+            for (int i = 0; i < binding.Controller.Count; i++) {
+                if (MInput.GamePads[jump.GamepadIndex].Check(binding.Controller[i], jump.Threshold)) {
+                    jumpKeysHeld++;
+                }
+            }
+
+            for (int i = 0; i < binding.Mouse.Count; i++) {
+                if (MInput.Mouse.Check(binding.Mouse[i])) {
+                    jumpKeysHeld++;
+                }
+            }
+
+            PhysicsLogHoldingJump = jumpKeysHeld > 0;
+            PhysicsLogHoldingSecondJump = jumpKeysHeld > 1;
         }
 
         public string GetInputsFormatted(char separator = ' ') {
@@ -731,12 +745,10 @@ namespace Celeste.Mod.ConsistencyTracker.PhysicsLog
                 inputs += $"{updown}{separator}";
             }
 
-            if (Input.Jump.Check) {
-                if (PhysicsLogHoldingSecondJump) {
-                    inputs += $"K{separator}";
-                } else {
-                    inputs += $"J{separator}";
-                }
+            if (PhysicsLogHoldingSecondJump) {
+                inputs += $"K{separator}";
+            } else if (PhysicsLogHoldingJump) {
+                inputs += $"J{separator}";
             }
 
             if (Input.Dash.Check) {


### PR DESCRIPTION
On the current version if you keep holding the first jump, and then press the second jump, and then release the second jump, the physics inspector would still think you're holding 2 jumps after you released the second jump.

I believe the issue is this method:
https://github.com/viddie/ConsistencyTrackerMod/blob/719ce60733957db4bd59ff490e645ada52976b64/PhysicsLog/PhysicsLogger.cs#L709-L720
This is my understanding of the issue: I kept holding the first jump, so `Input.Jump.Check` was always true -> I pressed the second jump, so `PhysicsLogHoldingSecondJump` was set to true -> I released the second jump while keeping holding the first jump, but `PhysicsLogHoldingSecondJump` was still true.

This pull request makes it check how many jump keys are held manually, instead of using `Input.Jump.Check` and `Input.Jump.Pressed`. From what I've tested, it works pretty fine and fixes the issue.