### PR TITLE
Fix DeathGraphs misalignment on resolutions higher than 1920x1080

### DIFF
--- a/Utility/DrawHelper.cs
+++ b/Utility/DrawHelper.cs
@@ -54,7 +54,7 @@ namespace Celeste.Mod.ConsistencyTracker.Utility {
             //    $"\n{matrix}" +
             //    $"\nEngine.ScreenMatrix.Translation: {m.Translation}");
 
-            DrawVertices(Matrix.Identity, vertices);
+            DrawVertices(m.M11 > 1.0001f ? Engine.ScreenMatrix : Matrix.Identity, vertices);
         }
 
         public static void DrawVertices(Matrix mat, VertexPositionColor[] vertices) {


### PR DESCRIPTION
This commit fixes a layout issue where the DeathGraphs were misaligned on resolutions higher than 1920x1080. 
Although I couldn't test it directly on 3840x2160, I've verified that the fix works perfectly on 2560x1440.
<img width="2560" height="1440" alt="20260721160550_1" src="https://github.com/user-attachments/assets/edb8adf0-3c0f-4467-8c37-983549015cb2" />
